### PR TITLE
Add Layout component

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,0 +1,6 @@
+const React = require("react")
+const Layout = require("./src/components/Layout/Layout").default
+
+exports.wrapPageElement = ({ element, props }) => {
+  return <Layout {...props}>{element}</Layout>
+}

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,0 +1,6 @@
+const React = require("react")
+const Layout = require("./src/components/Layout/Layout").default
+
+exports.wrapPageElement = ({ element, props }) => {
+  return <Layout {...props}>{element}</Layout>
+}

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import PropTypes from 'prop-types';
+
+const Layout = (props) => {
+    return (
+        <>
+            <div className="layout">
+                {props.children}
+            </div>
+        </>
+    );
+};
+
+export default Layout;
+
+Layout.propTypes = {
+    children: PropTypes.node.isRequired,
+};


### PR DESCRIPTION
I created the Layout component and used Gatsby's wrapPageElement API to wrap the Layout component around pages. This will allow the Layout component to be persistent across routes.

## Resources
[Gatsby Layout Component](https://www.gatsbyjs.com/docs/how-to/routing/layout-components/)