### PR TITLE
Add class to body to detect if JavaScript is enabled

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,5 +1,18 @@
+/**
+ * Implement Gatsby's Browser APIs in this file.
+ *
+ * See: https://www.gatsbyjs.org/docs/browser-apis/
+ */
+
 const React = require('react');
 const Layout = require('./src/components/Layout/Layout').default;
+
+exports.onClientEntry = () => {
+    document.body.className = document.body.className.replace(
+        /\bno-js\b/,
+        'js'
+    );
+};
 
 exports.wrapPageElement = ({ element, props }) => {
     return <Layout {...props}>{element}</Layout>;

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,5 +1,17 @@
+/**
+ * Implement Gatsby's SSR (Server Side Rendering) APIs in this file.
+ *
+ * See: https://www.gatsbyjs.org/docs/ssr-apis/
+ */
+ 
 const React = require('react');
 const Layout = require('./src/components/Layout/Layout').default;
+
+ exports.onRenderBody = ({ setBodyAttributes }) => {
+    setBodyAttributes({
+        className: 'no-js',
+    });
+};
 
 exports.wrapPageElement = ({ element, props }) => {
     return <Layout {...props}>{element}</Layout>;


### PR DESCRIPTION
I used Gatsby's SSR (Server Side Rendering) API to add a `no-js` class to the body and then used the Gatsby's Browser API to replace this class with `js` if JavaScript is disabled